### PR TITLE
Change the split character of the convert module

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -35,7 +35,7 @@ function handleFile(folder, file){
     file = file.trim();
 
     var f = fs.readFileSync(FORTUNE_FOLDER + folder + file, 'utf8');
-    var quotes = f.split('%');
+    var quotes = f.split('%\n');
 
     var quotesString = JSON.stringify(quotes, null, "  ");
    


### PR DESCRIPTION
There is a bug when a fortune text includes '%' characters. So I fixed that with adding new line character to split.